### PR TITLE
Remove jdbc prefix from the database url.

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-DATABASE_URL=jdbc:postgresql://localhost:5432/{{sanitized}}_dev
+DATABASE_URL=postgresql://localhost:5432/{{sanitized}}_dev
 SECRET={{secret}}
 PORT=1337
 COAST_ENV=dev


### PR DESCRIPTION
Migrations won't run otherwise.