### PR TITLE
Bump juxt/pack.alpha version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,24 +1,23 @@
 {:paths ["db" "resources" "src"]
 
  :deps
- {org.clojure/clojure {:mvn/version "1.10.0"}
+ {org.clojure/clojure         {:mvn/version "1.10.0"}
   coast-framework/coast.theta {:mvn/version "1.5.0"}
-  org.xerial/sqlite-jdbc {:mvn/version "3.25.2"}}
+  org.xerial/sqlite-jdbc      {:mvn/version "3.25.2"}}
 
  :aliases
  {:test
   {:extra-paths ["test"]
-   :main-opts ["-m" "cognitect.test-runner"]
+   :main-opts   ["-m" "cognitect.test-runner"]
    :extra-deps
    {com.cognitect/test-runner {:git/url "git@github.com:cognitect-labs/test-runner"
-                               :sha "5f2b5c2efb444df76fb5252102b33f542ebf7f58"}}}
+                               :sha     "5f2b5c2efb444df76fb5252102b33f542ebf7f58"}}}
 
   :uberjar
-  {:main-opts ["-m" "mach.pack.alpha.capsule"
-               "-m" "server"
-               "-e" "target"
-               "target/{{name}}.jar"]
+  {:main-opts  ["-m" "mach.pack.alpha.capsule"
+                "-m" "server"
+                "target/{{name}}.jar"]
    :extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
-                                 :sha "d9023b24c3d589ba6ebc66c5a25c0826ed28ead5"}}}
+                                 :sha     "2769a6224bfb938e777906ea311b3daf7d2220f5"}}}
 
   :repl {:extra-deps {nrepl {:mvn/version "0.6.0"}}}}}


### PR DESCRIPTION
This PR addresses [`make uberjar` failed: "java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter" #81](https://github.com/coast-framework/coast/issues/81)
* Bump `juxt/pack.alpha` to `2769a6224bfb938e777906ea311b3daf7d2220f5`.
* Add the empty target folder.
* Remove target from --extra-path to avoid infinite build time.