### PR TITLE
Update shipping instruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	COAST_ENV=test clj -A\:test
 
 clean:
-	rm -rf target
+	rm -rf target/*
 
 uberjar:
 	clj -A\:uberjar

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ curl http://localhost:1337 # or just open it in your browser
 make db/migrate
 make assets
 make uberjar
-java -jar target/{{name}}-1.0.0-standalone.jar -m server 1337
+java -jar target/{{name}}.jar 1337
 ```


### PR DESCRIPTION
Since we already provide the `:main-opts` of `"-m" "server"` to `juxt/pack.alpha`, we don't need to repeat it.