### PR TITLE
Remove main namespace option in uberjar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ curl http://localhost:1337 # or just open it in your browser
 make db/migrate
 make assets
 make uberjar
-java -jar target/{{name}}.jar 1337
+java -jar target/{{name}}.jar -m server 1337
 ```

--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,6 @@
 
   :uberjar
   {:main-opts  ["-m" "mach.pack.alpha.capsule"
-                "-m" "server"
                 "target/{{name}}.jar"]
    :extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
                                  :sha     "2769a6224bfb938e777906ea311b3daf7d2220f5"}}}


### PR DESCRIPTION
This addresses issue #5 .

* Remove the `"-m" "server"` option.
* Update README: to run the server with uberjar, use `java -jar <uberjar>.jar -m server 1337`.