### PR TITLE
Update org.xerial/sqlite-jdbc to 3.34.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
  :deps
  {org.clojure/clojure         {:mvn/version "1.10.0"}
   coast-framework/coast.theta {:mvn/version "1.6.0"}
-  org.xerial/sqlite-jdbc      {:mvn/version "3.25.2"}}
+  org.xerial/sqlite-jdbc      {:mvn/version "3.34.0"}}
 
  :aliases
  {:test


### PR DESCRIPTION
This will allow M1 macs to connect to an sqlite database via JDBC.
Without this version bump, an exception is raised whenever a database
operation is performed:

```
make db/migrate                                                                                                                                                           Apr  6, 08:53:15
clj -m coast.migrations migrate
WARNING: Implicit use of clojure.main with options is deprecated, use -M
Exception in thread "main" com.zaxxer.hikari.pool.HikariPool$PoolInitializationException: Failed to initialize pool: Error opening connection
	at com.zaxxer.hikari.pool.HikariPool.throwPoolInitializationException(HikariPool.java:569)
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:555)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:115)
	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:81)
	at coast.db.connection$pool.invokeStatic(connection.clj:63)
	at coast.db.connection$pool.invoke(connection.clj:35)
	at coast.db.connection$fn__440.invokeStatic(connection.clj:66)
	at coast.db.connection$fn__440.invoke(connection.clj:66)
	at clojure.lang.Delay.deref(Delay.java:42)
	at clojure.core$deref.invokeStatic(core.clj:2320)
	at clojure.core$deref.invoke(core.clj:2306)
	at coast.db.connection$connection.invokeStatic(connection.clj:68)
	at coast.db.connection$connection.invoke(connection.clj:68)
	at coast.migrations$create_table.invokeStatic(migrations.clj:31)
	at coast.migrations$create_table.invoke(migrations.clj:30)
	at coast.migrations$completed_migrations.invokeStatic(migrations.clj:38)
	at coast.migrations$completed_migrations.invoke(migrations.clj:37)
	at coast.migrations$pending.invokeStatic(migrations.clj:60)
	at coast.migrations$pending.invoke(migrations.clj:57)
	at coast.migrations$migrate.invokeStatic(migrations.clj:84)
	at coast.migrations$migrate.invoke(migrations.clj:83)
	at coast.migrations$_main.invokeStatic(migrations.clj:149)
	at coast.migrations$_main.invoke(migrations.clj:147)
	at clojure.lang.AFn.applyToHelper(AFn.java:154)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.core$apply.invokeStatic(core.clj:665)
	at clojure.main$main_opt.invokeStatic(main.clj:491)
	at clojure.main$main_opt.invoke(main.clj:487)
	at clojure.main$main.invokeStatic(main.clj:598)
	at clojure.main$main.doInvoke(main.clj:561)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:37)
Caused by: java.sql.SQLException: Error opening connection
	at org.sqlite.SQLiteConnection.open(SQLiteConnection.java:239)
	at org.sqlite.SQLiteConnection.<init>(SQLiteConnection.java:61)
	at org.sqlite.jdbc3.JDBC3Connection.<init>(JDBC3Connection.java:28)
	at org.sqlite.jdbc4.JDBC4Connection.<init>(JDBC4Connection.java:21)
	at org.sqlite.JDBC.createConnection(JDBC.java:116)
	at org.sqlite.SQLiteDataSource.getConnection(SQLiteDataSource.java:410)
	at org.sqlite.SQLiteDataSource.getConnection(SQLiteDataSource.java:398)
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:365)
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:194)
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:460)
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:534)
	... 32 more
Caused by: java.lang.Exception: No native library is found for os.name=Mac and os.arch=aarch64. path=/org/sqlite/native/Mac/aarch64
	at org.sqlite.SQLiteJDBCLoader.loadSQLiteNativeLibrary(SQLiteJDBCLoader.java:333)
	at org.sqlite.SQLiteJDBCLoader.initialize(SQLiteJDBCLoader.java:64)
	at org.sqlite.core.NativeDB.load(NativeDB.java:63)
	at org.sqlite.SQLiteConnection.open(SQLiteConnection.java:235)
	... 42 more

make: *** [db/migrate] Error 1
```