### PR TITLE
Bump sqlite driver to 3.39.3.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
  :deps
  {org.clojure/clojure         {:mvn/version "1.10.0"}
   coast-framework/coast.theta {:mvn/version "1.6.0"}
-  org.xerial/sqlite-jdbc      {:mvn/version "3.34.0"}}
+  org.xerial/sqlite-jdbc      {:mvn/version "3.39.3.0"}}
 
  :aliases
  {:test


### PR DESCRIPTION
This hopefully solves https://github.com/coast-framework/coast/issues/107 where @armstnp had a problem rolling back a create migration because sqlite hadn't implement alter table drop column until version 3.35.0